### PR TITLE
hash the file name for electron store

### DIFF
--- a/src/store/electron-store.js
+++ b/src/store/electron-store.js
@@ -9,6 +9,11 @@ export let namespacedElectronStore = null;
 
 export default store;
 
+/**
+ * create an electron store namespaced to the current url.
+ * The url is hashed since windows is more picky and doesn't allow :
+ * @param {string} url empire url
+ */
 export function initNamespacedStore(url) {
-  namespacedElectronStore = new Store({ name: url });
+  namespacedElectronStore = new Store({ name: btoa(url) });
 }


### PR DESCRIPTION
Fixes storing stagers in windows, which doesn't allow `:` in filenames