### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "electron:build": "yarn run electron:generate-icons && vue-cli-service electron:build",
     "electron:build:mac": "yarn run electron:generate-icons && vue-cli-service electron:build --mac",
     "electron:build:win": "yarn run electron:generate-icons && vue-cli-service electron:build --windows",
-    "electron:build:lin": "yarn run electron:generate-icons && vue-cli-service electron:build --linux",
+    "electron:build:lin": "yarn run electron:generate-icons && vue-cli-service electron:build --linux --x64 --arm64 --armv7l",
+    "_Linux": "--x64 --arm64 --armv7l adds arm64/arm7 and etc arches ",
     "electron:serve": "vue-cli-service electron:serve",
     "postinstall": "electron-builder install-app-deps",
     "postuninstall": "electron-builder install-app-deps"


### PR DESCRIPTION
yarn run build --linux --arm64 --armv7l , -mwl , https://www.electron.build/multi-platform-build  
rpm/deb /built-taballs ie for gentoo ebuild would be  a plus too. 
https://github.com/Zerx0r/Kage  # 21  i was able to rig a copy of kage on rpi4-64bit aarch64 rig a tarball build in much same way..